### PR TITLE
sale_validity: Migrate validity date module to 10.0

### DIFF
--- a/sale_validity/__manifest__.py
+++ b/sale_validity/__manifest__.py
@@ -19,13 +19,13 @@
 #
 #
 
-{"name": "Sales Quotation Validity Date",
- "version": "8.0.7.0.0",
- "depends": ["sale"],
- "author": "Camptocamp,Odoo Community Association (OCA)",
- "category": "Sales",
- "website": "http://www.camptocamp.com",
- "description": """
+{
+    "name": "Sales Quotation Validity Date",
+    "version": "10.0.1.0.0",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "category": "Sales",
+    "website": "http://www.camptocamp.com",
+    "description": """
 Sale order validity date
 ========================
 
@@ -35,12 +35,16 @@ until when the quotation is valid.
 A default validity duration (in days) can be configured on the company.
 
 """,
- 'data': [
-     "view/sale_order.xml",
-     "view/company_view.xml",
- ],
- 'test': [
-     'test/sale_validity.yml',
- ],
- 'installable': False,
- }
+    "depends": [
+        "sale"
+    ],
+    'data': [
+        "view/sale_order.xml",
+        "view/company_view.xml",
+    ],
+    'test': [
+        'test/sale_validity.yml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/sale_validity/model/sale_order.py
+++ b/sale_validity/model/sale_order.py
@@ -40,7 +40,7 @@ class SaleOrder(models.Model):
         date_validity_str = False
         company_pool = self.env['res.company']
         company_id = company_pool._company_default_get('sale.order')
-        company = company_pool.browse(company_id)
+        company = company_pool.browse(company_id.id)
         if company.default_sale_order_validity_days:
             today_str = fields.Date.context_today(self)
             today = fields.Date.from_string(today_str)

--- a/sale_validity/view/company_view.xml
+++ b/sale_validity/view/company_view.xml
@@ -13,10 +13,8 @@
     <field name="model">res.company</field>
     <field name="inherit_id" ref="base.view_company_form"/>
     <field name="arch" type="xml">
-        <xpath expr="//page[@string='Configuration']/group" position="inside">
-            <group name="sale_validity">
-                <field name="default_sale_order_validity_days"/>
-            </group>
+        <xpath expr="//field[@name='currency_id']" position="after">
+            <field name="default_sale_order_validity_days"/>
         </xpath>
     </field>
 </record>


### PR DESCRIPTION
I have migrated this module to 10.0. But after that, I saw in the sale model that there is a field "[validity_date](https://github.com/odoo/odoo/blob/10.0/addons/sale/models/sale.py#L120)" Isn't that a field with the same functionality? Maybe we should use that field in the module?