### PR TITLE
Extend existing `sale.order.cancel` wizard

### DIFF
--- a/sale_cancel_reason/tests/test_sale_cancel_reason.py
+++ b/sale_cancel_reason/tests/test_sale_cancel_reason.py
@@ -11,12 +11,10 @@ class TestSaleCancelReason(TransactionCase):
         - Then the sale order should be canceled and the reason stored
         """
         SaleOrderCancel = self.env["sale.order.cancel"]
-        context = {
-            "active_model": "sale.order",
-            "active_ids": [self.sale_order.id],
-        }
-        wizard = SaleOrderCancel.create({"reason_id": self.reason.id})
-        wizard.with_context(context).confirm_cancel()
+        wizard = SaleOrderCancel.with_context(
+            default_order_id=self.sale_order.id,
+        ).create({"reason_id": self.reason.id})
+        wizard.action_cancel()
         self.assertEqual(
             self.sale_order.state, "cancel", "the sale order should be canceled"
         )

--- a/sale_cancel_reason/view/sale_view.xml
+++ b/sale_cancel_reason/view/sale_view.xml
@@ -5,18 +5,6 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_cancel']" position="attributes">
-                <attribute name="invisible">True</attribute>
-            </xpath>
-            <xpath expr="//button[@name='action_cancel']" position="before">
-                <button
-                    name="%(action_sale_order_cancel)d"
-                    states="draft,sent,sale"
-                    string="Cancel Order"
-                    type="action"
-                    groups="base.group_user"
-                />
-            </xpath>
             <xpath expr="/form/sheet/div/h1" position="after">
                 <h2 attrs="{'invisible': [('state', '!=', 'cancel')]}">
                     <label for="cancel_reason_id" string="Cancellation reason:" />

--- a/sale_cancel_reason/wizard/cancel_reason.py
+++ b/sale_cancel_reason/wizard/cancel_reason.py
@@ -5,21 +5,14 @@ from odoo import fields, models
 
 class SaleOrderCancel(models.TransientModel):
 
-    """ Ask a reason for the sale order cancellation."""
+    """Ask a reason for the sale order cancellation."""
 
-    _name = "sale.order.cancel"
-    _description = __doc__
+    _inherit = "sale.order.cancel"
 
     reason_id = fields.Many2one(comodel_name="sale.order.cancel.reason", required=True)
 
-    def confirm_cancel(self):
+    def action_cancel(self):
         self.ensure_one()
-        act_close = {"type": "ir.actions.act_window_close"}
-        sale_ids = self.env.context.get("active_ids")
-        if sale_ids is None:
-            return act_close
-        assert len(sale_ids) == 1, "Only 1 sale ID expected"
-        sale = self.env["sale.order"].browse(sale_ids)
-        sale.cancel_reason_id = self.reason_id.id
-        sale.action_cancel()
-        return act_close
+        res = super().action_cancel()
+        self.order_id.cancel_reason_id = self.reason_id
+        return res

--- a/sale_cancel_reason/wizard/cancel_reason_view.xml
+++ b/sale_cancel_reason/wizard/cancel_reason_view.xml
@@ -1,36 +1,22 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="view_sale_order_cancel" model="ir.ui.view">
-        <field name="name">Reason for the cancellation</field>
-        <field name="model">sale.order.cancel</field>
-        <field name="arch" type="xml">
-            <form string="Reason for the cancellation" version="7.0">
-                <p class="oe_grey">
+
+<record id="sale_order_cancel_view_form" model="ir.ui.view">
+    <field name="model">sale.order.cancel</field>
+    <field name="inherit_id" ref="sale.sale_order_cancel_view_form" />
+    <field name="arch" type="xml">
+
+        <footer position="before">
+            <p class="oe_grey">
                 Choose the reason for the cancellation of the
                 sale order.
             </p>
-                <group>
-                    <field name="reason_id" widget="selection" />
-                </group>
-                <footer>
-                <button
-                        name="confirm_cancel"
-                        string="Confirm"
-                        type="object"
-                        class="oe_highlight"
-                    />
-                or
-                <button string="Cancel" class="oe_link" special="cancel" />
-            </footer>
-            </form>
-        </field>
-    </record>
-    <record id="action_sale_order_cancel" model="ir.actions.act_window">
-        <field name="name">Reason for the cancellation</field>
-        <field name="type">ir.actions.act_window</field>
-        <field name="res_model">sale.order.cancel</field>
-        <field name="view_mode">form</field>
-        <field name="view_id" ref="view_sale_order_cancel" />
-        <field name="target">new</field>
-    </record>
+            <group>
+                <field name="reason_id" widget="selection" />
+            </group>
+        </footer>
+
+    </field>
+</record>
+
 </odoo>


### PR DESCRIPTION
In Odoo 14.0 `sale.order.cancel` wizard is added by the `sale` addon.