### PR TITLE
[FIX] sale_blanket_order - proper taxes computation

### DIFF
--- a/sale_blanket_order/views/sale_blanket_order_views.xml
+++ b/sale_blanket_order/views/sale_blanket_order_views.xml
@@ -212,6 +212,7 @@
                                         groups="analytic.group_analytic_accounting"
                                         force_save="1"
                                     />
+                                    <field name="fiscal_position_id" />
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
Correct taxes computation according to fiscal position:
* Add `fiscal_position_id` into form view
* Add `onchange` method to properly recompute taxes after fiscal position change

https://hive.versada.eu/work_packages/19991/activity

Created [issue](https://github.com/OCA/sale-workflow/issues/2440) and [PR](https://github.com/OCA/sale-workflow/pull/2439) to OCA