### PR TITLE
[FIX] sale_invoice_policy: invoice_policy

### DIFF
--- a/sale_invoice_policy/models/sale_order.py
+++ b/sale_invoice_policy/models/sale_order.py
@@ -9,7 +9,6 @@ class SaleOrder(models.Model):
 
     invoice_policy = fields.Selection(
         [("order", "Ordered quantities"), ("delivery", "Delivered quantities")],
-        readonly=True,
         help="Ordered Quantity: Invoice based on the quantity the customer "
         "ordered.\n"
         "Delivered Quantity: Invoiced based on the quantity the vendor "


### PR DESCRIPTION
Allow empty value on invoice_policy by removing readonly option. Without this it's not possible to select nothing which forces always to use invoice policy from sale order level.